### PR TITLE
Makefile: Support a custom binary name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PREFIX =	$(PREFIX)
 else
 PREFIX =	/usr
 endif
+BINNAM =	pdksh
 BINDIR = 	$(DESTDIR)/bin
 MANDIR =	$(DESTDIR)$(PREFIX)/man
 TMP ?= /tmp
@@ -33,14 +34,14 @@ all: $(PROG)
 
 check test:
 	/usr/bin/perl tests/th -s tests -p ./ksh -T $(TMP) \
-		-C pdksh,sh,ksh,posix,posix-upu
+		-C $(BINNAM),sh,ksh,posix,posix-upu
 
 install:
 	install -m755 -d $(BINDIR)
-	install -m755 --strip --no-target-directory ksh $(BINDIR)/pdksh
+	install -m755 --strip --no-target-directory ksh $(BINDIR)/$(BINNAM)
 	install -m755 -d $(MANDIR)/man1
-	install -m644 --no-target-directory ksh.1 $(MANDIR)/man1/pdksh.1
-	install -m644 --no-target-directory sh.1 $(MANDIR)/man1/pdksh-sh.1
+	install -m644 --no-target-directory ksh.1 $(MANDIR)/man1/$(BINNAM).1
+	install -m644 --no-target-directory sh.1 $(MANDIR)/man1/$(BINNAM)-sh.1
 
 clean:
 	rm -f $(OBJS) $(PROG)


### PR DESCRIPTION
This allows installing ksh-openbsd with another name than `pdksh` as its possible there could be another `pdksh` on the system. As before `pdksh` is the default.